### PR TITLE
precommit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .direnv
+.pre-commit-config.yaml
 
 # docs-serve stuff
 /mkdocs.yml

--- a/flake.lock
+++ b/flake.lock
@@ -98,6 +98,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -163,6 +179,45 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -252,6 +307,32 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708018599,
+        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "attic": "attic",
@@ -261,10 +342,26 @@
         "flake-root": "flake-root",
         "hercules-ci-effects": "hercules-ci-effects",
         "nixpkgs": "nixpkgs_2",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "treefmt-nix": "treefmt-nix"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,11 @@
       url = "github:zhaofengli/attic";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    pre-commit-hooks-nix = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs-stable.follows = "nixpkgs"; # prevent unnecessary download
+    };
   };
   outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {

--- a/shell/default.nix
+++ b/shell/default.nix
@@ -1,6 +1,11 @@
-{inputs, ...}: {
+{
+  inputs,
+  lib,
+  ...
+}: {
   imports = [
     inputs.devshell.flakeModule
+    inputs.pre-commit-hooks-nix.flakeModule
   ];
 
   perSystem = {
@@ -15,12 +20,19 @@
           ❄️ Welcome to the {14}{bold}cardano.nix{reset} devshell ❄️
           $(type -p menu &>/dev/null && menu)
         '';
+        startup = {
+          pre-commit = lib.noDepEntry "eval ${config.pre-commit.installationScript}";
+        };
       };
       packages = with pkgs; [
         statix
         config.treefmt.build.wrapper
         reuse
       ];
+    };
+    pre-commit.settings = {
+      hooks.treefmt.enable = true;
+      settings.treefmt.package = config.treefmt.build.wrapper;
     };
   };
 }

--- a/shell/default.nix
+++ b/shell/default.nix
@@ -1,8 +1,4 @@
-{
-  inputs,
-  lib,
-  ...
-}: {
+{inputs, ...}: {
   imports = [
     inputs.devshell.flakeModule
     inputs.pre-commit-hooks-nix.flakeModule
@@ -19,15 +15,21 @@
         motd = ''
           ❄️ Welcome to the {14}{bold}cardano.nix{reset} devshell ❄️
           $(type -p menu &>/dev/null && menu)
+          $(type -p update-pre-commit-hooks &>/dev/null && update-pre-commit-hooks)
         '';
-        startup = {
-          pre-commit = lib.noDepEntry "eval ${config.pre-commit.installationScript}";
-        };
       };
       packages = with pkgs; [
         statix
         config.treefmt.build.wrapper
         reuse
+      ];
+      commands = [
+        {
+          name = "update-pre-commit-hooks";
+          command = config.pre-commit.installationScript;
+          category = "Tools";
+          help = "Update pre-commit-hooks";
+        }
       ];
     };
     pre-commit.settings = {


### PR DESCRIPTION
Prototyping solution for #22 

I not satisfied it much, because injecting into devshell is very hacky (or doesn't work with direnv, and require explicit `nix develop` at least once).
Also still doubt, if we need it or not.

Open list of questions:
* May be worth to move `deadnix` from treefmt to pre-commit?
* May be worth run full `nix flake check` instead of "just treefmt"