### PR TITLE
update packages, remove multiple version support

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -102,7 +102,7 @@
         githubUrl = "https://github.com/mlabs-haskell/cardano.nix/tree/main";
       }
       {
-        storePath = inputs."cardano-node-9.2.1".outPath;
+        storePath = inputs.cardano-node.outPath;
         githubUrl = "https://github.com/IntersectMBO/cardano-node/tree/master";
       }
       {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,28 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1727170555,
-        "narHash": "sha256-kxB/xjSjqym5kKYDw/CZMb6O1OfCVWRjjsuqyWABd0w=",
+        "lastModified": 1730824761,
+        "narHash": "sha256-Kv99PeYWdqmj5OStnp6kE6fjHbx6irTYyEPoFuukfHU=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-haskell-packages",
+        "rev": "d3d36220528058f9a24cff43fc723e60f6a786ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
+    "CHaP_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1730295876,
+        "narHash": "sha256-ijnHTQ6eKIQ9FpEqDKt6c7vuFYN8aOBDhonp67utx2s=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "d8beaf7e30330f8a70e626f63a5b47d1999fbf4b",
+        "rev": "25591f43ab943d5a070db5e8a2b9ff3a499d4d92",
         "type": "github"
       },
       "original": {
@@ -18,6 +35,22 @@
       }
     },
     "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_2": {
       "flake": false,
       "locked": {
         "lastModified": 1451647621,
@@ -68,16 +101,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1722435302,
-        "narHash": "sha256-VFPOdOjdpFa3HP6gIgbxVtJsvsL/NU6yPfnxEhHUeTs=",
+        "lastModified": 1730408279,
+        "narHash": "sha256-YeSPvCrfc0OmMqhzGN/WXcBSfXIlnEnqWemzqQTz+zw=",
         "owner": "blockfrost",
         "repo": "blockfrost-backend-ryo",
-        "rev": "a54513b83904e8761c4a6fb880238a8d5f3124ed",
+        "rev": "30ec8cf23d9c222199dc5afba9b79b5bfeec3337",
         "type": "github"
       },
       "original": {
         "owner": "blockfrost",
-        "ref": "v2.1.0",
+        "ref": "v2.2.4",
         "repo": "blockfrost-backend-ryo",
         "type": "github"
       }
@@ -85,17 +118,17 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "lastModified": 1691598027,
+        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
+        "ref": "v0.3.11",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
         "type": "github"
       }
     },
@@ -133,6 +166,23 @@
         "type": "github"
       }
     },
+    "cabal-32_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -150,7 +200,41 @@
         "type": "github"
       }
     },
+    "cabal-34_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_2": {
       "flake": false,
       "locked": {
         "lastModified": 1669081697,
@@ -186,11 +270,11 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "haskellNix": [
-          "cardano-node-92",
+          "cardano-node",
           "haskellNix"
         ],
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "nixpkgs"
         ],
         "tullia": "tullia"
@@ -209,35 +293,12 @@
         "type": "github"
       }
     },
-    "cardano-configurations-9.2.1": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1721870874,
-        "narHash": "sha256-qiReN+xxtbb4kEfdIWbBcqcJpPGD8he0p/TVD7U3CqM=",
-        "owner": "input-output-hk",
-        "repo": "cardano-configurations",
-        "rev": "7969a73e5c7ee1f3b2a40274b34191fdd8de170b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-configurations",
-        "rev": "7969a73e5c7ee1f3b2a40274b34191fdd8de170b",
-        "type": "github"
-      }
-    },
     "cardano-db-sync": {
       "inputs": {
-        "CHaP": [
-          "cardano-node-92",
-          "CHaP"
-        ],
+        "CHaP": "CHaP",
         "flake-compat": "flake-compat",
         "hackageNix": "hackageNix",
-        "haskellNix": [
-          "cardano-node-92",
-          "haskellNix"
-        ],
+        "haskellNix": "haskellNix",
         "iohkNix": "iohkNix",
         "nixpkgs": [
           "cardano-db-sync",
@@ -247,23 +308,23 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1720817009,
-        "narHash": "sha256-FGcAR160WhZvnhdeyWDaKSltcY6jqv0q/B9CUtj24hc=",
+        "lastModified": 1731069075,
+        "narHash": "sha256-EESfv4KVXjYokTMQLwJGkhOq6gskiXCjF3rfDNDaeXQ=",
         "owner": "intersectmbo",
         "repo": "cardano-db-sync",
-        "rev": "d21895fec3a9445493b6ff4aa61b8dcb5153de1e",
+        "rev": "5b131e97210cf603a3aca5ddca7d1420f9cabeec",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
-        "ref": "13.3.0.0",
+        "ref": "13.6.0.1",
         "repo": "cardano-db-sync",
         "type": "github"
       }
     },
     "cardano-mainnet-mirror": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -280,24 +341,24 @@
         "type": "github"
       }
     },
-    "cardano-node-92": {
+    "cardano-node": {
       "inputs": {
-        "CHaP": "CHaP",
+        "CHaP": "CHaP_2",
         "cardano-automation": "cardano-automation",
         "cardano-mainnet-mirror": "cardano-mainnet-mirror",
         "customConfig": "customConfig",
         "em": "em",
         "empty-flake": "empty-flake",
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_4",
         "hackageNix": "hackageNix_2",
-        "haskellNix": "haskellNix",
+        "haskellNix": "haskellNix_2",
         "hostNixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "nixpkgs"
         ],
         "iohkNix": "iohkNix_2",
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "haskellNix",
           "nixpkgs-unstable"
         ],
@@ -306,16 +367,16 @@
         "utils": "utils_3"
       },
       "locked": {
-        "lastModified": 1727221818,
-        "narHash": "sha256-i582YpBy+hBth73JqfcjGFsJrTQeDG0NJ7vN8JLWeoI=",
+        "lastModified": 1730468447,
+        "narHash": "sha256-yNEv7MQEcOPY9I9k9RCzeMfJY6gzuGc7K53GKNHs6v8=",
         "owner": "intersectmbo",
         "repo": "cardano-node",
-        "rev": "5d3da8ac771ee5ed424d6c78473c11deabb7a1f3",
+        "rev": "01bda2e2cb0a70cd95067d696dbb44665f1d680a",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
-        "ref": "9.2.1",
+        "ref": "10.1.2",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -336,18 +397,29 @@
         "type": "github"
       }
     },
-    "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
+    "cardano-shell_2": {
+      "flake": false,
       "locked": {
-        "lastModified": 1721058578,
-        "narHash": "sha256-fs/PVa3H5dS1//4BjecWi3nitXm5fRObx0JxXIAo+JA=",
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1731098351,
+        "narHash": "sha256-HQkYvKvaLQqNa10KEFGgWHfMAbWBfFp+4cAgkut+NNE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "17e5109bb1d9fb393d70fba80988f7d70d1ded1a",
+        "rev": "ef80ead953c1b28316cc3f8613904edc2eb90c28",
         "type": "github"
       },
       "original": {
@@ -374,11 +446,11 @@
     "devour-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1694098737,
-        "narHash": "sha256-O51F4YFOzlaQAc9b6xjkAqpvrvCtw/Os2M7TU0y4SKQ=",
+        "lastModified": 1726283167,
+        "narHash": "sha256-Cvc84VzvvdmehafnaIPfdPylNWJcDmv79QQh/MH/4Qk=",
         "owner": "srid",
         "repo": "devour-flake",
-        "rev": "30a34036b29b0d12989ef6c8be77aa949d85aef5",
+        "rev": "9b96d31a55be119df8496ec5b7369823deec8a1c",
         "type": "github"
       },
       "original": {
@@ -390,14 +462,14 @@
     "devshell": {
       "inputs": {
         "flake-utils": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
           "flake-utils"
         ],
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
@@ -422,15 +494,14 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "systems": "systems_3"
+        ]
       },
       "locked": {
-        "lastModified": 1695973661,
-        "narHash": "sha256-BP2H4c42GThPIhERtTpV1yCtwQHYHEKdRu7pjrmQAwo=",
+        "lastModified": 1728330715,
+        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "cd4e2fda3150dd2f689caeac07b7f47df5197c31",
+        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
         "type": "github"
       },
       "original": {
@@ -442,14 +513,14 @@
     "dmerge": {
       "inputs": {
         "nixlib": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
           "nixpkgs"
         ],
         "yants": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
@@ -473,17 +544,17 @@
     "dmerge_2": {
       "inputs": {
         "haumea": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "haumea"
         ],
         "nixlib": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "lib"
         ],
         "yants": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "yants"
         ]
@@ -554,6 +625,23 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
         "lastModified": 1650374568,
         "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
@@ -567,7 +655,7 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1647532380,
@@ -584,7 +672,7 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
+    "flake-compat_5": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -601,7 +689,7 @@
         "type": "github"
       }
     },
-    "flake-compat_5": {
+    "flake-compat_6": {
       "flake": false,
       "locked": {
         "lastModified": 1696426674,
@@ -622,11 +710,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -637,11 +725,11 @@
     },
     "flake-root": {
       "locked": {
-        "lastModified": 1692742795,
-        "narHash": "sha256-f+Y0YhVCIJ06LemO+3Xx00lIcqQxSKJHXT/yk1RTKxw=",
+        "lastModified": 1723604017,
+        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
         "owner": "srid",
         "repo": "flake-root",
-        "rev": "d9a70d9c7a5fd7f3258ccf48da9335e9b47c3937",
+        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
         "type": "github"
       },
       "original": {
@@ -710,25 +798,24 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
-      "inputs": {
-        "systems": "systems_4"
-      },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
+    "ghc-8.6.5-iohk_2": {
       "flake": false,
       "locked": {
         "lastModified": 1600920045,
@@ -790,11 +877,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703887061,
-        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -805,7 +892,7 @@
     },
     "gomod2nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "utils": "utils_2"
       },
       "locked": {
@@ -825,11 +912,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1702945378,
-        "narHash": "sha256-mo1MlOphO4bRwZ8T3mDwU5LOtdQcWSA+93lT1HkCcyw=",
+        "lastModified": 1729470551,
+        "narHash": "sha256-AKBK4jgOjIz5DxIsIKFZR0mf30qc4Dv+Dm/DVRjdjD8=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e59b9616a744727e8e64f605f9f216464f12f89b",
+        "rev": "ee5b803d828db6efac3ef7e7e072c855287dc298",
         "type": "github"
       },
       "original": {
@@ -841,11 +928,11 @@
     "hackageNix_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1725928375,
-        "narHash": "sha256-XO/6kJ77bR99bAuRGr9PleQX75vde5CbSU+6Xf3e8NQ=",
+        "lastModified": 1729039425,
+        "narHash": "sha256-sIglYcw8Dacj4n0bRlUWo+NLkDMcVi6vtmKvUyG+ZrQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "68cfb288b958e9d7a1329df614684132f44bd2b3",
+        "rev": "6dc43e5e01f113ce151056a8f94bce7bb2f13eb9",
         "type": "github"
       },
       "original": {
@@ -861,12 +948,10 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc910X": "ghc910X",
-        "ghc911": "ghc911",
         "hackage": [
-          "cardano-node-92",
+          "cardano-db-sync",
           "hackageNix"
         ],
         "hls-1.10": "hls-1.10",
@@ -883,8 +968,9 @@
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
-          "cardano-node-92",
-          "nixpkgs"
+          "cardano-db-sync",
+          "haskellNix",
+          "nixpkgs-unstable"
         ],
         "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2105": "nixpkgs-2105",
@@ -893,9 +979,66 @@
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1729471867,
+        "narHash": "sha256-xMxD8YQGGcbrZGHJws32UvtWJxfhzAO7yzPs5TjiOPY=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "03c3581d2e0c91f7c2690115b487961ad62099a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix_2": {
+      "inputs": {
+        "HTTP": "HTTP_2",
+        "cabal-32": "cabal-32_2",
+        "cabal-34": "cabal-34_2",
+        "cabal-36": "cabal-36_2",
+        "cardano-shell": "cardano-shell_2",
+        "flake-compat": "flake-compat_5",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
+        "ghc910X": "ghc910X",
+        "ghc911": "ghc911",
+        "hackage": [
+          "cardano-node",
+          "hackageNix"
+        ],
+        "hls-1.10": "hls-1.10_2",
+        "hls-2.0": "hls-2.0_2",
+        "hls-2.2": "hls-2.2_2",
+        "hls-2.3": "hls-2.3_2",
+        "hls-2.4": "hls-2.4_2",
+        "hls-2.5": "hls-2.5_2",
+        "hls-2.6": "hls-2.6_2",
+        "hls-2.7": "hls-2.7_2",
+        "hls-2.8": "hls-2.8_2",
+        "hpc-coveralls": "hpc-coveralls_2",
+        "hydra": "hydra_2",
+        "iserv-proxy": "iserv-proxy_2",
+        "nixpkgs": [
+          "cardano-node",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_2",
+        "nixpkgs-2105": "nixpkgs-2105_2",
+        "nixpkgs-2111": "nixpkgs-2111_2",
+        "nixpkgs-2205": "nixpkgs-2205_2",
+        "nixpkgs-2211": "nixpkgs-2211_2",
+        "nixpkgs-2305": "nixpkgs-2305_2",
+        "nixpkgs-2311": "nixpkgs-2311_2",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "old-ghc-nix": "old-ghc-nix_2",
+        "stackage": "stackage_2"
       },
       "locked": {
         "lastModified": 1718797200,
@@ -908,13 +1051,14 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
         "type": "github"
       }
     },
     "haumea": {
       "inputs": {
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "lib"
         ]
@@ -944,11 +1088,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710396488,
-        "narHash": "sha256-yniBB5i1un44uzR4+luTWvZ6uGvsHSYIBiDZ8Xox4nQ=",
+        "lastModified": 1714676393,
+        "narHash": "sha256-OA2LZPTCHyH0PcsNkjeTLvgsn4JmsV2VTvXQacHeUZU=",
         "owner": "mlabs-haskell",
         "repo": "hercules-ci-effects",
-        "rev": "f5ed263ab0585dfb7b067301419fb80d64e8c021",
+        "rev": "5ad8f9613b735cb4f8222f07ae45ca37bfe76a23",
         "type": "github"
       },
       "original": {
@@ -959,6 +1103,23 @@
       }
     },
     "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10_2": {
       "flake": false,
       "locked": {
         "lastModified": 1680000865,
@@ -992,7 +1153,41 @@
         "type": "github"
       }
     },
+    "hls-2.0_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2_2": {
       "flake": false,
       "locked": {
         "lastModified": 1693064058,
@@ -1026,7 +1221,41 @@
         "type": "github"
       }
     },
+    "hls-2.3_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4_2": {
       "flake": false,
       "locked": {
         "lastModified": 1699862708,
@@ -1060,7 +1289,41 @@
         "type": "github"
       }
     },
+    "hls-2.5_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6_2": {
       "flake": false,
       "locked": {
         "lastModified": 1705325287,
@@ -1094,7 +1357,41 @@
         "type": "github"
       }
     },
+    "hls-2.7_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8_2": {
       "flake": false,
       "locked": {
         "lastModified": 1715153580,
@@ -1114,7 +1411,7 @@
     "hls-2.9": {
       "flake": false,
       "locked": {
-        "lastModified": 1718469202,
+        "lastModified": 1720003792,
         "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
         "owner": "haskell",
         "repo": "haskell-language-server",
@@ -1144,11 +1441,51 @@
         "type": "github"
       }
     },
+    "hpc-coveralls_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
     "hydra": {
       "inputs": {
         "nix": "nix",
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-db-sync",
+          "haskellNix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_2": {
+      "inputs": {
+        "nix": "nix_2",
+        "nixpkgs": [
+          "cardano-node",
           "haskellNix",
           "hydra",
           "nix",
@@ -1171,7 +1508,7 @@
     "incl": {
       "inputs": {
         "nixlib": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "lib"
         ]
@@ -1201,11 +1538,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1698999258,
-        "narHash": "sha256-42D1BMbdyZD+lT+pWUzb5zDQyasNbMJtH/7stuPuPfE=",
+        "lastModified": 1730297014,
+        "narHash": "sha256-n3f1iAmltKnorHWx7FrdbGIF/FmEG8SsZshS16vnpz0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "73dc2bb45af6f20cfe1d962f1334eed5e84ae764",
+        "rev": "d407eedd4995e88d08e83ef75844a8a9c2e29b36",
         "type": "github"
       },
       "original": {
@@ -1218,18 +1555,18 @@
       "inputs": {
         "blst": "blst_2",
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "nixpkgs"
         ],
         "secp256k1": "secp256k1_2",
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1721825987,
-        "narHash": "sha256-PPcma4tjozwXJAWf+YtHUQUulmxwulVlwSQzKItx/n8=",
+        "lastModified": 1728687575,
+        "narHash": "sha256-38uD8SqT557eh5yyRYuthKm1yTtiWzAN0FH7L/01QKM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "eb61f2c14e1f610ec59117ad40f8690cddbf80cb",
+        "rev": "86c2bd46e8a08f62ea38ffe77cb4e9c337b42217",
         "type": "github"
       },
       "original": {
@@ -1239,6 +1576,23 @@
       }
     },
     "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717479972,
+        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "iserv-proxy_2": {
       "flake": false,
       "locked": {
         "lastModified": 1717479972,
@@ -1286,6 +1640,22 @@
         "type": "github"
       }
     },
+    "lowdown-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
     "mdbook-kroki-preprocessor": {
       "flake": false,
       "locked": {
@@ -1306,7 +1676,7 @@
       "inputs": {
         "flake-utils": "flake-utils_4",
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
@@ -1330,7 +1700,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -1350,9 +1720,9 @@
     },
     "nix-nomad": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "flake-utils": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "nix2container",
@@ -1360,13 +1730,13 @@
         ],
         "gomod2nix": "gomod2nix",
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "nixpkgs"
         ],
         "nixpkgs-lib": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "nixpkgs"
@@ -1389,7 +1759,7 @@
     "nix2container": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1658567952,
@@ -1405,24 +1775,45 @@
         "type": "github"
       }
     },
+    "nix_2": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_2",
+        "nixpkgs": "nixpkgs_7",
+        "nixpkgs-regression": "nixpkgs-regression_2"
+      },
+      "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.11.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixago": {
       "inputs": {
         "flake-utils": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
           "flake-utils"
         ],
         "nixago-exts": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
           "blank"
         ],
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
@@ -1475,7 +1866,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2003_2": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_2": {
       "locked": {
         "lastModified": 1659914493,
         "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
@@ -1507,7 +1930,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2111_2": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205_2": {
       "locked": {
         "lastModified": 1685573264,
         "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
@@ -1539,7 +1994,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2211_2": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305_2": {
       "locked": {
         "lastModified": 1701362232,
         "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
@@ -1557,6 +2044,22 @@
     },
     "nixpkgs-2311": {
       "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311_2": {
+      "locked": {
         "lastModified": 1701386440,
         "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
         "owner": "NixOS",
@@ -1571,22 +2074,32 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
+    "nixpkgs-2405": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1726447378,
+        "narHash": "sha256-2yV8nmYE1p9lfmLHhOCbYwQC/W8WYfGQABoGzJOb1JQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "086b448a5d54fd117f4dc2dee55c9f0ff461bdc1",
         "type": "github"
       },
       "original": {
-        "dir": "lib",
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -1605,7 +2118,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-regression_2": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1726583932,
+        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "658e7223191d2598641d50ee4e898126768fe847",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_2": {
       "locked": {
         "lastModified": 1694822471,
         "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
@@ -1623,6 +2168,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1653581809,
         "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
         "owner": "NixOS",
@@ -1637,7 +2198,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1654807842,
         "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
@@ -1652,7 +2213,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1665087388,
         "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
@@ -1668,7 +2229,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1642336556,
         "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
@@ -1682,7 +2243,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
@@ -1698,7 +2259,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1708343346,
         "narHash": "sha256-qlzHvterVRzS8fS0ophQpkh0rqw0abijHEOAKm0HmV0=",
@@ -1714,13 +2275,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
-        "lastModified": 1728492678,
-        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "lastModified": 1731319897,
+        "narHash": "sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY+/Z96ZcLpooIbuEI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
         "type": "github"
       },
       "original": {
@@ -1762,6 +2323,23 @@
         "type": "github"
       }
     },
+    "old-ghc-nix_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
     "ops-lib": {
       "flake": false,
       "locked": {
@@ -1786,16 +2364,16 @@
         "utils": "utils_4"
       },
       "locked": {
-        "lastModified": 1724784734,
-        "narHash": "sha256-+rFPyNqo75wQ8vll8LutoqHwH7H3gdPNkmMQqPx+BrI=",
+        "lastModified": 1729716427,
+        "narHash": "sha256-gZhY/Xh63VLsiGzfpwoKSSmTJwguiRfOjPry+cD5pmM=",
         "owner": "txpipe",
         "repo": "oura",
-        "rev": "2fb369d7e9176feda74f270261b59f7d2ee35bc7",
+        "rev": "c6bfc5ab66a82cc6a59de5d3a3d3f01f5543b961",
         "type": "github"
       },
       "original": {
         "owner": "txpipe",
-        "ref": "v1.9.1",
+        "ref": "v1.9.2",
         "repo": "oura",
         "type": "github"
       }
@@ -1804,13 +2382,13 @@
       "inputs": {
         "call-flake": "call-flake",
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "nixpkgs"
         ],
         "nosys": "nosys",
         "yants": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "yants"
         ]
@@ -1849,8 +2427,7 @@
     },
     "pre-commit-hooks-nix": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
-        "flake-utils": "flake-utils_5",
+        "flake-compat": "flake-compat_6",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -1860,11 +2437,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708018599,
-        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
         "type": "github"
       },
       "original": {
@@ -1876,19 +2453,15 @@
     "root": {
       "inputs": {
         "blockfrost": "blockfrost",
-        "cardano-configurations-9.2.1": "cardano-configurations-9.2.1",
         "cardano-db-sync": "cardano-db-sync",
-        "cardano-node-9.2.1": [
-          "cardano-node-92"
-        ],
-        "cardano-node-92": "cardano-node-92",
+        "cardano-node": "cardano-node",
         "crane": "crane",
         "devour-flake": "devour-flake",
         "devshell": "devshell_2",
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "hercules-ci-effects": "hercules-ci-effects",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_9",
         "oura": "oura",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "treefmt-nix": "treefmt-nix"
@@ -1965,6 +2538,22 @@
     "stackage": {
       "flake": false,
       "locked": {
+        "lastModified": 1729039017,
+        "narHash": "sha256-fGExfgG+7UNSOV8YfOrWPpOHWrCjA02gQkeSBhaAzjQ=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "df1d8f0960407551fea7af7af75a9c2f9e18de97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1718756571,
         "narHash": "sha256-8rL8viTbuE9/yV1of6SWp2tHmhVMD2UmkOfmN5KDbKg=",
         "owner": "input-output-hk",
@@ -1985,7 +2574,7 @@
         "dmerge": "dmerge",
         "flake-utils": "flake-utils_3",
         "makes": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
@@ -1993,7 +2582,7 @@
         ],
         "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
         "microvm": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
@@ -2001,7 +2590,7 @@
         ],
         "n2c": "n2c",
         "nixago": "nixago",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "yants": "yants"
       },
       "locked": {
@@ -2021,13 +2610,13 @@
     "std_2": {
       "inputs": {
         "arion": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "blank"
         ],
         "blank": "blank_2",
         "devshell": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "blank"
         ],
@@ -2036,30 +2625,30 @@
         "incl": "incl",
         "lib": "lib",
         "makes": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "blank"
         ],
         "microvm": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "blank"
         ],
         "n2c": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "blank"
         ],
         "nixago": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "blank"
         ],
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_8",
         "paisano": "paisano",
         "paisano-tui": "paisano-tui",
         "terranix": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "blank"
         ],
@@ -2109,36 +2698,6 @@
         "type": "github"
       }
     },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -2146,11 +2705,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697388351,
-        "narHash": "sha256-63N2eBpKaziIy4R44vjpUu8Nz5fCJY7okKrkixvDQmY=",
+        "lastModified": 1730321837,
+        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "aae39f64f5ecbe89792d05eacea5cb241891292a",
+        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
         "type": "github"
       },
       "original": {
@@ -2164,7 +2723,7 @@
         "nix-nomad": "nix-nomad",
         "nix2container": "nix2container",
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "nixpkgs"
         ],
@@ -2189,11 +2748,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -2253,7 +2812,7 @@
     "yants": {
       "inputs": {
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "cardano-automation",
           "tullia",
           "std",
@@ -2277,7 +2836,7 @@
     "yants_2": {
       "inputs": {
         "nixpkgs": [
-          "cardano-node-92",
+          "cardano-node",
           "std",
           "lib"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -4,39 +4,27 @@
       url = "github:NixOS/nixpkgs/nixos-unstable";
     };
 
-    # Cardano-node
-    # FIXME: dots not allowed in `.follows.` statements
-    "cardano-node-92" = {
-      url = "github:intersectmbo/cardano-node?ref=9.2.1";
-    };
-    "cardano-node-9.2.1".follows = "cardano-node-92";
-    "cardano-configurations-9.2.1" = {
-      # This version is compatible with cardano-node above and likely needs to be updated together.
-      url = "github:input-output-hk/cardano-configurations/7969a73e5c7ee1f3b2a40274b34191fdd8de170b";
-      flake = false;
-    };
-
     # Services
-    cardano-db-sync = {
-      url = "github:intersectmbo/cardano-db-sync/13.3.0.0"; # compatible with cardano-node 9.2.1
 
-      # Following cardano-node's haskell-nix and CHaP, it fix build issue with download from ci.zw3rk
-      inputs.haskellNix.follows = "cardano-node-92/haskellNix";
-      inputs.CHaP.follows = "cardano-node-92/CHaP";
+    "cardano-node" = {
+      url = "github:intersectmbo/cardano-node/10.1.2";
+    };
+    cardano-db-sync = {
+      url = "github:intersectmbo/cardano-db-sync/13.6.0.1";
     };
     blockfrost = {
-      url = "github:blockfrost/blockfrost-backend-ryo/v2.1.0"; # compatible with cardano-db-sync 13.3.0.0
+      url = "github:blockfrost/blockfrost-backend-ryo/v2.2.4";
     };
     oura = {
-      url = "github:txpipe/oura/v1.9.1";
+      url = "github:txpipe/oura/v1.9.2";
       inputs.crane.follows = "crane";
     };
     crane = {
       url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # Utilities
+
     devour-flake = {
       url = "github:srid/devour-flake";
       flake = false;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -18,7 +18,7 @@
     };
     node = {
       imports = [
-        inputs."cardano-node-9.2.1".nixosModules.cardano-node
+        inputs.cardano-node.nixosModules.cardano-node
         ./node.nix
       ];
     };

--- a/packages/cardano.nix
+++ b/packages/cardano.nix
@@ -1,19 +1,7 @@
-{
-  inputs,
-  lib,
-  ...
-}: {
-  perSystem = {
-    pkgs,
-    system,
-    ...
-  }: {
-    packages = lib.filterAttrs (_: v: v != null) {
-      "cardano-cli-9.2.1" = inputs."cardano-node-9.2.1".packages.${system}.cardano-cli or null;
-      "cardano-node-9.2.1" = inputs."cardano-node-9.2.1".packages.${system}.cardano-node or null;
-      "cardano-configurations-9.2.1" = pkgs.runCommandNoCC "cardano-configurations" {} ''
-        ln -s ${inputs."cardano-configurations-9.2.1"} $out
-      '';
+{inputs, ...}: {
+  perSystem = {system, ...}: {
+    packages = {
+      inherit (inputs.cardano-node.packages.${system}) cardano-cli cardano-node;
     };
   };
 }

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -4,37 +4,10 @@
     ./ogmios.nix
     ./kupo.nix
     ./oura.nix
-    # TODO add support for multiple blockfrost versions and re-export derivations from this flake
   ];
-  perSystem = {system, ...}: {
-    # add default package versions under attribute names without version
-    packages = config.flake.overlays.default {inherit system;} {};
-  };
   flake.overlays = {
-    default = config.flake.overlays."cardano-node-9.2.1";
-    "cardano-node-9.2.1" = final: _prev:
-    # overlay for recent packages
-    let
-      inherit (config.perSystem final.system) packages;
-    in {
-      cardano-cli = packages."cardano-cli-9.2.1";
-      cardano-node = packages."cardano-node-9.2.1";
-      cardano-configurations = packages."cardano-configurations-9.2.1";
-      ogmios = packages."ogmios-6.6.2";
-      kupo = packages."kupo-2.8.0";
-      oura = packages."oura-1.9.1";
-    };
-    "cardano-node-8.1.1" = final: _prev:
-    # overlay for packages compatible with cardano-transaction-lib 8.0.0
-    let
-      inherit (config.perSystem final.system) packages;
-    in {
-      cardano-cli = packages."cardano-cli-8.1.1";
-      cardano-node = packages."cardano-node-8.1.1";
-      cardano-configurations = packages."cardano-configurations-8.1.1";
-      ogmios = packages."ogmios-6.0.3";
-      kupo = packages."kupo-2.6.1";
-      oura = packages."oura-1.8.6";
+    default = final: _prev: {
+      inherit ((config.perSystem final.system).packages) cardano-cli cardano-node ogmios kupo oura;
     };
   };
 }

--- a/packages/kupo.nix
+++ b/packages/kupo.nix
@@ -1,46 +1,21 @@
-{
-  perSystem = {
-    system,
-    pkgs,
-    lib,
-    ...
-  }: let
-    truncateVersion = version: builtins.head (builtins.match "v?([0-9]+\\.[0-9]+).*" version);
-    mkUrl = version: variant: archive: "https://github.com/CardanoSolutions/kupo/releases/download/v${truncateVersion version}/kupo-${version}-${variant}.${archive}";
-    releases = {
-      "2.9.0" = {
-        "x86_64-linux" = {
-          url = mkUrl "v2.9.0" "x86_64-linux" "zip";
-          hash = "sha256-sEfaFPph1qBuPrxQzFeTKU/9i9w0KF/v7GpxxmorPWQ=";
-        };
-      };
-      "2.8.0" = {
-        "x86_64-linux" = {
-          url = mkUrl "2.8.0" "amd64-Linux" "tar.gz";
-          hash = "sha256-k6js0R0psyeHnM6q0e4slu4ESXm1FMiVRO2JUlsnlHY=";
-        };
-      };
-      "2.6.1" = {
-        "x86_64-linux" = {
-          url = mkUrl "2.6.1" "amd64-Linux" "tar.gz";
-          hash = "sha256-pK+1ncKirqoTcC42pR5x0Oc9xXCAm2ajt9oRWZjNeyQ=";
-        };
-      };
+let
+  truncateVersion = version: builtins.head (builtins.match "v?([0-9]+\\.[0-9]+).*" version);
+  mkUrl = system: version: "https://github.com/CardanoSolutions/kupo/releases/download/v${truncateVersion version}/kupo-${version}-${system}.zip";
+  mkPackage = pkgs: version: hash:
+    pkgs.fetchzip
+    {
+      url = mkUrl pkgs.system version;
+      inherit hash;
+      stripRoot = false;
+      name = "kupo-${version}";
+      postFetch = "chmod +x $out/bin/kupo";
+    }
+    // {
+      inherit version;
+      inherit mkPackage;
     };
-    mkPackage = version:
-      pkgs.fetchzip {
-        inherit (releases.${version}.${system}) url hash;
-        stripRoot = false;
-        name = "kupo-${version}";
-        postFetch = "chmod +x $out/bin/kupo";
-      }
-      // {inherit version;};
-  in {
-    packages =
-      lib.mapAttrs' (v: _: {
-        name = "kupo-${v}";
-        value = mkPackage v;
-      })
-      releases;
+in {
+  perSystem = {pkgs, ...}: {
+    packages.kupo = mkPackage pkgs "2.9.0" "sha256-sEfaFPph1qBuPrxQzFeTKU/9i9w0KF/v7GpxxmorPWQ=";
   };
 }

--- a/packages/ogmios.nix
+++ b/packages/ogmios.nix
@@ -1,81 +1,20 @@
-{
-  perSystem = {
-    system,
-    pkgs,
-    lib,
-    ...
-  }: let
-    mkUrl = version: system: "https://github.com/CardanoSolutions/ogmios/releases/download/v${version}/ogmios-v${version}-${system}.zip";
-    releases = {
-      "6.8.0" = {
-        "x86_64-linux" = {
-          url = mkUrl "6.8.0" "x86_64-linux";
-          hash = "sha256-PM3tB6YdFsXRxGptDuxOvLke0m/08ySy4oV1WfIu//g=";
-        };
-      };
-      "6.7.0" = {
-        "x86_64-linux" = {
-          url = mkUrl "6.7.0" "x86_64-linux";
-          hash = "sha256-GWn7VhP6U/PnJHBNorF9hB0+UTtyolTTyfLr63wYWt0=";
-        };
-      };
-      "6.6.2" = {
-        "x86_64-linux" = {
-          url = mkUrl "6.6.2" "x86_64-linux";
-          hash = "sha256-KHOna+zDFJDVD20M2dTD71dcDKWMSXmqOPWMAYef9/4=";
-        };
-      };
-      "6.5.0" = {
-        "x86_64-linux" = {
-          url = mkUrl "6.5.0" "x86_64-linux";
-          hash = "sha256-C7vwUefYXCXhnfIUt/Kmj3/f4cd3IogAZxaBtDftUOU=";
-        };
-      };
-      "6.4.0" = {
-        "x86_64-linux" = {
-          url = mkUrl "6.4.0" "x86_64-linux";
-          hash = "sha256-yUdHcnf4K28DS+opILENCtE4fn32qhDylxyptarGnJE=";
-        };
-      };
-      "6.3.0" = {
-        "x86_64-linux" = {
-          url = mkUrl "6.3.0" "x86_64-linux";
-          hash = "sha256-sl16WKX1WTNENrt1STbgDjtYiQTx1NmAJ6L4miryA8E=";
-        };
-      };
-      "6.2.0" = {
-        "x86_64-linux" = {
-          url = mkUrl "6.2.0" "x86_64-linux";
-          hash = "sha256-FxYJLAVLhW/YYmaTSkBCWung/BjAqvPotUXWHvo+Aqs=";
-        };
-      };
-      "6.1.0" = {
-        "x86_64-linux" = {
-          url = mkUrl "6.1.0" "x86_64-linux";
-          hash = "sha256-8Qj9/EZo4t5o8BN/ystkTTfvoqtUIYY9GJYACX+bTUY=";
-        };
-      };
-      "6.0.3" = {
-        "x86_64-linux" = {
-          url = mkUrl "6.0.3" "x86_64-linux";
-          hash = "sha256-Gn6c17Dfyb4M4ec/94LFJSS1y0S0wS8KciEz9s7uIEw=";
-        };
-      };
+let
+  mkUrl = system: version: "https://github.com/CardanoSolutions/ogmios/releases/download/v${version}/ogmios-v${version}-${system}.zip";
+  mkPackage = pkgs: version: hash:
+    pkgs.fetchzip
+    {
+      name = "ogmios-${version}";
+      url = mkUrl pkgs.system version;
+      inherit hash;
+      stripRoot = false;
+      postFetch = "chmod +x $out/bin/ogmios";
+    }
+    // {
+      inherit version;
+      inherit mkPackage;
     };
-    mkPackage = version:
-      pkgs.fetchzip {
-        inherit (releases.${version}.${system}) url hash;
-        stripRoot = false;
-        name = "ogmios-${version}";
-        postFetch = "chmod +x $out/bin/ogmios";
-      }
-      // {inherit version;};
-  in {
-    packages =
-      lib.mapAttrs' (v: _: {
-        name = "ogmios-${v}";
-        value = mkPackage v;
-      })
-      releases;
+in {
+  perSystem = {pkgs, ...}: {
+    packages.ogmios = mkPackage pkgs "6.8.0" "sha256-PM3tB6YdFsXRxGptDuxOvLke0m/08ySy4oV1WfIu//g=";
   };
 }

--- a/packages/oura.nix
+++ b/packages/oura.nix
@@ -11,8 +11,6 @@
       src = craneLib.cleanCargoSource inputs.oura;
     };
   in {
-    packages = {
-      "oura-${oura.version}" = oura;
-    };
+    packages.oura = oura;
   };
 }


### PR DESCRIPTION
- need to update cardano-node since it will not sync latest blocks
- remove support for multiple versions, it adds complications. use older cardano.nix version to use old packages

maybe we should write a short doc to show how to override versions