### PR TITLE
Indirection layer for node

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -10,6 +10,7 @@
     cardano = {
       imports = [
         ./cardano.nix
+        ./providers.nix
       ];
     };
     cli = {

--- a/modules/node.nix
+++ b/modules/node.nix
@@ -111,5 +111,14 @@ in
         chmod g+rw ${cfg.socketPath}
       '';
     };
+
+    # Register as default node socket for others `cardano.nix` consumers
+    cardano.providers.node = {
+      active = true;
+      inherit (cfg) socketPath;
+      accessGroup = "cardano-node";
+      requires = "cardano-node-socket.service";
+      after = "cardano-node-socket.service";
+    };
   };
 }

--- a/modules/oura.nix
+++ b/modules/oura.nix
@@ -31,7 +31,7 @@ in
           type = "N2C";
           address = [
             "Unix"
-            config.cardano.node.socketPath
+            config.cardano.providers.node.socketPath
           ];
           magic = config.cardano.network;
         };
@@ -39,9 +39,9 @@ in
       };
     };
 
-    systemd.services.oura = lib.mkIf (config.cardano.node.enable or false) {
-      after = [ "cardano-node-socket.service" ];
-      requires = [ "cardano-node-socket.service" ];
+    systemd.services.oura = lib.mkIf config.cardano.providers.node.active {
+      after = [ config.cardano.providers.node.after ];
+      requires = [ config.cardano.providers.node.requires ];
     };
   };
 }

--- a/modules/providers.nix
+++ b/modules/providers.nix
@@ -1,0 +1,58 @@
+# Design defence:
+# The goal of this module is to introduce an indirection layer for service
+# dependencies: consumers reference a provider instead of binding to a specific
+# systemd unit. This makes it possible to transparently switch between a local
+# cardano-node and a remote tunnel (e.g. from Demeter run). Common options are
+# factored into `sharedOptions` to unify the contract and reduce duplication.
+# Options are currently marked as `internal = true` until proper documentation
+# is written.
+{
+  lib,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+  sharedOptions = {
+    active = mkOption {
+      type = types.bool;
+      internal = true;
+      default = false;
+      description = ''
+        Mark service provider as active
+      '';
+    };
+    accessGroup = mkOption {
+      type = types.str;
+      internal = true;
+      description = ''
+        Group to access service provider
+      '';
+    };
+    requires = mkOption {
+      type = types.str;
+      internal = true;
+      description = ''
+        Systemd's service name to add to `requires` by all consumers
+      '';
+    };
+    after = mkOption {
+      type = types.str;
+      internal = true;
+      description = ''
+        Systemd's service name to add to `after` by all consumers
+      '';
+    };
+  };
+in
+{
+  options.cardano.providers = {
+    node = sharedOptions // {
+      socketPath = mkOption {
+        type = types.path;
+        description = ''
+          Cardano node socket path, to refer by consumers
+        '';
+      };
+    };
+  };
+}

--- a/packages/kupo.nix
+++ b/packages/kupo.nix
@@ -1,6 +1,6 @@
 let
   truncateVersion = version: builtins.head (builtins.match "v?([0-9]+\\.[0-9]+).*" version);
-  mkUrl = system: version: "https://github.com/CardanoSolutions/kupo/releases/download/v${truncateVersion version}/kupo-${version}-${system}.zip";
+  mkUrl = system: version: "https://github.com/CardanoSolutions/kupo/releases/download/v${truncateVersion version}/kupo-v${version}-${system}.zip";
   mkPackage =
     pkgs: version: hash:
     pkgs.fetchzip {
@@ -19,6 +19,6 @@ in
   perSystem =
     { pkgs, ... }:
     {
-      packages.kupo = mkPackage pkgs "2.9.0" "sha256-sEfaFPph1qBuPrxQzFeTKU/9i9w0KF/v7GpxxmorPWQ=";
+      packages.kupo = mkPackage pkgs "2.11.0" "sha256-kOYenPdLEYwub4obEsgMEkytZQN/9CF64pfeS1Jr5QY=";
     };
 }


### PR DESCRIPTION
This PR include:
* bump of kupo (existing url pointed to non-exist file, so I fixed and updated it)
* add indirection layer for `cardano.providers.node` (and switch `oura` into it to test)

TODO:
* add demeter-run module (as alternative "provider" for node)
* switch kupo, blockfrost and ogmios to use "providers"
* Implement providers for kupo, blockfrost and ogmios