### PR TITLE
chore: Regular dependency update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1776203472,
-        "narHash": "sha256-husRfOULFemi5q+JpO7deykZxTKSIz0E4fCR387aO3Y=",
+        "lastModified": 1777742585,
+        "narHash": "sha256-ZzXz2vOhqethlqPgBExPXEnKWvaTbidsIxh5MGv+pwE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "3831817e4131b3ef5fe262e3f853b87bec8a24a0",
+        "rev": "e8a483522ee73c8c9493ea6055553e5c2532e66b",
         "type": "github"
       },
       "original": {
@@ -88,16 +88,16 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1739372843,
-        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "lastModified": 1749204514,
+        "narHash": "sha256-Q9/zGN93TnJt2c8YvSaURstoxT02ts3nVkO5V08m4TI=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.14",
+        "ref": "v0.3.15",
         "repo": "blst",
         "type": "github"
       }
@@ -286,16 +286,16 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1776219966,
-        "narHash": "sha256-D2HMIr65q0RM9+ZAjbtA9xNKyoKYfr3Kc4Vv4+s64uY=",
+        "lastModified": 1777953209,
+        "narHash": "sha256-+dod+EL73MICgbgflyJnwDlxbCeaBbBLrr2tLX59hAA=",
         "owner": "intersectmbo",
         "repo": "cardano-node",
-        "rev": "045bc187a36ef0cbd236db902b85dd8f202fb059",
+        "rev": "97036a66bcf8c89f687ae57a048eecc0389977ef",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
-        "ref": "10.7.1",
+        "ref": "11.0.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -1311,11 +1311,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1774280402,
-        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
+        "lastModified": 1777941182,
+        "narHash": "sha256-FX3+8GIrB2z4akmcYTStELDKVJWgqy9yFt0mxwpU3Qc=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
+        "rev": "9de00113c11ba8cac908a63acf34b193cda7475b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1770910700,
-        "narHash": "sha256-oOQrIwKKJ0uOqkIuf9G3L6MZ0PaKlxOIwRKz6Dv6b1k=",
+        "lastModified": 1777849188,
+        "narHash": "sha256-kJwRwMoGnFkgqeX/PEDrvx33qrVb8hVppqxmlcMnddc=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "2d8d9a4b0e911fa31340b3c7e669c898956acadf",
+        "rev": "28bb010c42a79526697f429e4ef536e3aa131dd7",
         "type": "github"
       },
       "original": {
@@ -119,23 +119,6 @@
         "type": "github"
       }
     },
-    "cabal-32_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -207,7 +190,7 @@
     "cardano-automation": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "hackageNix": "hackageNix",
+        "hackageNix": "hackageNix_2",
         "haskellNix": [
           "cardano-node",
           "haskellNix"
@@ -237,32 +220,31 @@
         "flake-compat": [
           "flake-compat_"
         ],
-        "hackageNix": [
-          "hackageNix_"
-        ],
+        "hackageNix": "hackageNix",
         "haskellNix": "haskellNix",
         "iohkNix": [
           "iohkNix_"
         ],
         "nixpkgs": [
-          "cardano-node",
-          "nixpkgs"
+          "cardano-db-sync",
+          "haskellNix",
+          "nixpkgs-unstable"
         ],
         "utils": [
           "flake-utils_"
         ]
       },
       "locked": {
-        "lastModified": 1771212271,
-        "narHash": "sha256-9wrlypHCKjC6biJa0Ip2Mfwvfm7Uc3Ex6GUZQa1Tstk=",
+        "lastModified": 1781697119,
+        "narHash": "sha256-mhG6kUpch9vZsqlsDkOjJaloLaXxp+2purwnS6wDZ2w=",
         "owner": "intersectmbo",
         "repo": "cardano-db-sync",
-        "rev": "3c8724b10ccea570bec282633d15e71160aa8344",
+        "rev": "db8cdf668cda632e9a09c30e1159fcb9fb34e952",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
-        "ref": "13.7.0.1",
+        "ref": "13.7.2.1",
         "repo": "cardano-db-sync",
         "type": "github"
       }
@@ -274,7 +256,7 @@
         "customConfig": "customConfig",
         "empty-flake": "empty-flake",
         "flake-compat": "flake-compat_2",
-        "hackageNix": "hackageNix_2",
+        "hackageNix": "hackageNix_3",
         "haskellNix": "haskellNix_2",
         "incl": "incl",
         "iohkNix": "iohkNix",
@@ -578,11 +560,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1763080018,
-        "narHash": "sha256-dhF1WJwKf3crYYZ1IzpZKvYrL2Vn9wJkaiwWz7KKLLU=",
+        "lastModified": 1773707598,
+        "narHash": "sha256-f0Lu4NojTVGdCocjpuF2vjy1RFU3IsJh4b6DnR39RBY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "0fe00885ac43275b806a5f357bd1bb543f4bd0dc",
+        "rev": "f2fa92265915b5e471fc2083eb9489ae32680651",
         "type": "github"
       },
       "original": {
@@ -644,6 +626,22 @@
     "hackageNix": {
       "flake": false,
       "locked": {
+        "lastModified": 1782652361,
+        "narHash": "sha256-WO7QWI2Xy9sPTk0tbDfjko+/+mSOS53HYnVWFnRje2M=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "c7677b938edecdd0a6be1f747252cadec1690497",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1759154585,
         "narHash": "sha256-OC5Y3E20bwkfMVlB2uhf7eF/FcuC1JD/BXkxR8rMjR4=",
         "owner": "input-output-hk",
@@ -657,7 +655,7 @@
         "type": "github"
       }
     },
-    "hackageNix_2": {
+    "hackageNix_3": {
       "flake": false,
       "locked": {
         "lastModified": 1774557316,
@@ -676,7 +674,6 @@
     "haskellNix": {
       "inputs": {
         "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
@@ -692,6 +689,7 @@
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
         "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -712,16 +710,17 @@
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1763081503,
-        "narHash": "sha256-4IBIATcInZQj3fMIB9nYxxCoXVUHTMlp6QvwVl4f0o4=",
+        "lastModified": 1773708983,
+        "narHash": "sha256-582WSt65FVqgFpb2Xx8+FaqNJWxwG1Bkt8L/z5X5yvo=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7631ffad2f38eacd75afa1dfa1c86ec1af548f16",
+        "rev": "545ccfeef07d1100ad0eae9009139ef4706943ee",
         "type": "github"
       },
       "original": {
@@ -733,7 +732,7 @@
     "haskellNix_2": {
       "inputs": {
         "HTTP": "HTTP_2",
-        "cabal-32": "cabal-32_2",
+        "cabal-32": "cabal-32",
         "cabal-34": "cabal-34_2",
         "cabal-36": "cabal-36_2",
         "cardano-shell": "cardano-shell_2",
@@ -958,6 +957,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -1327,11 +1343,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "lastModified": 1770174258,
+        "narHash": "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "rev": "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6",
         "type": "github"
       },
       "original": {
@@ -1487,11 +1503,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
@@ -1519,11 +1535,11 @@
     },
     "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1757716134,
-        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
         "type": "github"
       },
       "original": {
@@ -1549,13 +1565,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
         "type": "github"
       },
       "original": {
@@ -1733,11 +1765,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1763079199,
-        "narHash": "sha256-3DEm6AtrCHJhmkOPNXPZ40YQ2E7vrpgXuuASu/Bff5A=",
+        "lastModified": 1773706737,
+        "narHash": "sha256-oU6CvBAgeL1VnlINHeiOAUgrPh7/htlbxAET+735CxE=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "183c1aa28a2bf3c1a73ed879b7b22620af628f4e",
+        "rev": "3f97967ec75887b30a9d3aa3b3c3a328012ef525",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -73,16 +73,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1774862298,
-        "narHash": "sha256-3HwgpKlF+mAg4dPVc35B2k8bV9k2IQiINUnTLhLaFPQ=",
+        "lastModified": 1782229768,
+        "narHash": "sha256-P6txF/Mf6Fo81MLSLGdIsBP4Gqlj0fc3oHebepWvIUU=",
         "owner": "blockfrost",
         "repo": "blockfrost-backend-ryo",
-        "rev": "563bd3682483f9a6ea238c78efae084ceb034eab",
+        "rev": "4b1ceebe508daf8b846c3beb0a8edd320b0d5c07",
         "type": "github"
       },
       "original": {
         "owner": "blockfrost",
-        "ref": "v6.4.0",
+        "ref": "v6.7.0",
         "repo": "blockfrost-backend-ryo",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -68,9 +68,7 @@
     },
     "blockfrost": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs_"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1782229768,
@@ -1377,16 +1375,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769170682,
-        "narHash": "sha256-oMmN1lVQU0F0W2k6OI3bgdzp2YOHWYUAw79qzDSjenU=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5296fdd05cfa2c187990dd909864da9658df755",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1583,6 +1581,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1782375420,
+        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -1674,7 +1688,7 @@
           "cardano-node",
           "iohkNix"
         ],
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs_": [
           "nixpkgs"
         ],
@@ -1770,11 +1784,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769353635,
-        "narHash": "sha256-J0G1ACrUK29M0THPAsz429eZX07GmR9Bs/b0pB3N0dQ=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "f46bb205f239b415309f58166f8df6919fa88377",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
     };
 
     blockfrost = {
-      url = "github:blockfrost/blockfrost-backend-ryo/v6.4.0";
+      url = "github:blockfrost/blockfrost-backend-ryo/v6.7.0";
       inputs.nixpkgs.follows = "nixpkgs_";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   # Utilities
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
@@ -59,7 +59,8 @@
 
     blockfrost = {
       url = "github:blockfrost/blockfrost-backend-ryo/v6.7.0";
-      inputs.nixpkgs.follows = "nixpkgs_";
+      # Following nixpkgs didn't work anymore, new nodejs package breaks blockfrost
+      # inputs.nixpkgs.follows = "nixpkgs_";
     };
 
     oura = {

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
 
   # Services
   inputs = {
-    cardano-node.url = "github:intersectmbo/cardano-node/10.7.1"; # following `nixpkgs_` doesn'work
+    cardano-node.url = "github:intersectmbo/cardano-node/11.0.1"; # following `nixpkgs_` doesn'work
 
     cardano-db-sync = {
       url = "github:intersectmbo/cardano-db-sync/13.7.0.1";

--- a/flake.nix
+++ b/flake.nix
@@ -47,11 +47,12 @@
     cardano-node.url = "github:intersectmbo/cardano-node/11.0.1"; # following `nixpkgs_` doesn'work
 
     cardano-db-sync = {
-      url = "github:intersectmbo/cardano-db-sync/13.7.0.1";
+      url = "github:intersectmbo/cardano-db-sync/13.7.2.1";
       inputs = {
-        nixpkgs.follows = "cardano-node/nixpkgs"; # following `nixpkgs_` doesn't work
+        # following `nixpkgs_` not `cardano-node/nixpkgs` doesn't work
+        #nixpkgs.follows = "nixpkgs_";
         utils.follows = "flake-utils_";
-        hackageNix.follows = "hackageNix_";
+        #hackageNix.follows = "hackageNix_";
         iohkNix.follows = "iohkNix_";
         flake-compat.follows = "flake-compat_";
       };

--- a/modules/monitoring.nix
+++ b/modules/monitoring.nix
@@ -7,6 +7,7 @@
 let
   cfg = config.cardano.monitoring;
   inherit (lib)
+    mkDefault
     mkIf
     mkEnableOption
     mkMerge
@@ -109,6 +110,15 @@ in
         settings = {
           server = {
             http_addr = "0.0.0.0";
+          };
+          security = {
+            # - Grafana's secret key (services.grafana.settings.security.secret_key) doesn't have a default
+            #   value anymore. Please generate your own and use a file-provider on this option! See also
+            #   https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#secret_key for more information.
+            #
+            # As stated in the NixOS changelog for 26.05, there's no official way to rotate.
+            # Either hard-code the old key ("SW2YcwTIb9zpOOhoPsMm") if your setup doesn't have any secrets in the DB that need
+            secret_key = mkDefault (builtins.trace "Warning (cardano.nix): insecure graphana key used" "SW2YcwTIb9zpOOhoPsMm");
           };
         };
         provision = {

--- a/packages/ogmios.nix
+++ b/packages/ogmios.nix
@@ -18,6 +18,6 @@ in
   perSystem =
     { pkgs, ... }:
     {
-      packages.ogmios = mkPackage pkgs "6.14.0" "sha256-luN05hKGwB00y0mSTGAexi+l7edMfBSEg7WenGEMO6o=";
+      packages.ogmios = mkPackage pkgs "7.0.0" "sha256-BbxmfLNlYBXBrhq0JC1RahBympZJfqUnLa6XeRE1U/k=";
     };
 }


### PR DESCRIPTION
feat(cardano-db-sync): bump 13.7.0.1 -> 13.7.2.1
feat(ogmios): bump 6.14.0 -> 7.0.0
feat(cardano-node): bump 10.7.1 -> 11.0.1
feat(blockfrost): 6.4.0 -> 6.7.0
nixpkgs base branch also updated, pinned to 26.05 stable